### PR TITLE
Add ipAuthMaxSession parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ at *Realm settings* -> *User profile*. Create the attributes as follows:
   * *Permission*
       * *Who can edit?*: `Admin`
       * *Who can view?*: `Admin`
+* *Attribute*: `ipAuthMaxSession`
+  * *General settings*
+      * *Multivalued*: `Off`
+      * *Enabled when*: `Always`
+      * *Required field*: `Off`
+  * *Permission*
+      * *Who can edit?*: `Admin`
+      * *Who can view?*: `Admin`
+  * *Validations*
+    * *Validator name*: `integer`
+    * set min and max value for the parameter
 
 ### 3) Enable IP Authentication for Users
 Finally, you have to enable authentication by IP address for some users by setting the `ipAuthEnabled` user profile 

--- a/src/main/java/org/n52/keycloak/authentication/IPUserAuthenticator.java
+++ b/src/main/java/org/n52/keycloak/authentication/IPUserAuthenticator.java
@@ -128,7 +128,7 @@ public class IPUserAuthenticator extends AbstractUsernameFormAuthenticator {
             }
 
             if (maxSessions > 0 && activeSessions >= maxSessions) {
-                LOG.warn(MessageFormat.format("Maximum session number reached for user ''{0}''.", user.getId()));
+                LOG.warn(MessageFormat.format("Maximum session number reached ({0}) for user ''{1}''.", maxSessions, user.getId()));
 
                 context.failureChallenge(
                     AuthenticationFlowError.ACCESS_DENIED,

--- a/src/main/java/org/n52/keycloak/authentication/IPUserAuthenticator.java
+++ b/src/main/java/org/n52/keycloak/authentication/IPUserAuthenticator.java
@@ -25,6 +25,7 @@ public class IPUserAuthenticator extends AbstractUsernameFormAuthenticator {
 
     private static final String IP_AUTH_ENABLED_ATTR = "ipAuthEnabled";
     private static final String IP_AUTH_RANGES_ATTR = "ipAuthRanges";
+    private static final String IP_AUTH_MAX_SESSION = "ipAuthMaxSession";
     private static final String INVALID_IP_ERROR_MESSAGE = "invalid-ip-error";
     private static final String LOGIN_FORM = "login-ip.ftl";
 
@@ -106,6 +107,17 @@ public class IPUserAuthenticator extends AbstractUsernameFormAuthenticator {
         if (!enabledUser(context, user)) {
             return false;
         }
+        RealmModel realm = context.getRealm();
+        long activeSessions = context.getSession()
+            .sessions()
+            .getUserSessionsStream(realm, user)
+            .count();
+        int maxSessions = Integer.parseInt(user.getFirstAttribute(IP_AUTH_MAX_SESSION));
+        if (activeSessions >= maxSessions) {
+            LOG.warn(MessageFormat.format("Maximum session number reach for user ''{0}''.", user.getId()));
+            return false;
+        }
+
         //TODO Check if we need remember me handling
         LOG.debug(MessageFormat.format("Validated user ''{0}''.", user.getId()));
         context.setUser(user);

--- a/src/main/java/org/n52/keycloak/authentication/IPUserAuthenticator.java
+++ b/src/main/java/org/n52/keycloak/authentication/IPUserAuthenticator.java
@@ -118,26 +118,24 @@ public class IPUserAuthenticator extends AbstractUsernameFormAuthenticator {
             .count();
 
         String maxSessionsAttr = user.getFirstAttribute(IP_AUTH_MAX_SESSION);
-        if (maxSessionsAttr == null) {
-            return true; // no limit
-        }
+        if (maxSessionsAttr != null) {
+            int maxSessions;
+            try {
+                maxSessions = Integer.parseInt(maxSessionsAttr);
+            } catch (NumberFormatException e) {
+                LOG.warn(MessageFormat.format("Invalid max session attribute for user ''{0}''.", user.getId()));
+                return false;
+            }
 
-        int maxSessions;
-        try {
-            maxSessions = Integer.parseInt(maxSessionsAttr);
-        } catch (NumberFormatException e) {
-            LOG.warn(MessageFormat.format("Invalid max session attribute for user ''{0}''.", user.getId()));
-            return true;
-        }
+            if (maxSessions > 0 && activeSessions >= maxSessions) {
+                LOG.warn(MessageFormat.format("Maximum session number reached for user ''{0}''.", user.getId()));
 
-        if (maxSessions > 0 && activeSessions >= maxSessions) {
-            LOG.warn(MessageFormat.format("Maximum session number reached for user ''{0}''.", user.getId()));
-
-            context.failureChallenge(
-                AuthenticationFlowError.ACCESS_DENIED,
-                challenge(context, MAX_NUM_SESSIONS_MESSAGE)
-            );
-            return false;
+                context.failureChallenge(
+                    AuthenticationFlowError.ACCESS_DENIED,
+                    challenge(context, MAX_NUM_SESSIONS_MESSAGE)
+                );
+                return false;
+            }
         }
 
         //TODO Check if we need remember me handling

--- a/src/main/resources/theme-resources/messages/messages_ar.properties
+++ b/src/main/resources/theme-resources/messages/messages_ar.properties
@@ -1,0 +1,6 @@
+invalid-ip-error=عنوان IP غير صالح.
+missing-ip-error=عنوان IP مفقود في رأس HTTP المحول.
+ip-user-authenticator-display-name=عنوان IP
+ip-user-authenticator-help-text=تسجيل الدخول تلقائيًا باستخدام عنوان IP الحالي الخاص بك.
+ipAuthText=تسجيل الدخول تلقائيًا إلى حسابك باستخدام عنوان IP الخاص بك.
+max-num-session-error=تم الوصول إلى الحد الأقصى لعدد الجلسات المتزامنة.

--- a/src/main/resources/theme-resources/messages/messages_de.properties
+++ b/src/main/resources/theme-resources/messages/messages_de.properties
@@ -3,3 +3,4 @@ missing-ip-error=Fehlende IP-Adresse im HTTP Forwarded Header.
 ip-user-authenticator-display-name=IP-Adresse
 ip-user-authenticator-help-text=Automatisches Anmelden über die aktuelle IP-Adresse.
 ipAuthText=Melden Sie sich automatisch bei Ihrem Konto mit ihrer IP-Adresse an.
+max-num-session-error=Maximale Anzahl gleichzeitiger Sitzungen erreicht.

--- a/src/main/resources/theme-resources/messages/messages_en.properties
+++ b/src/main/resources/theme-resources/messages/messages_en.properties
@@ -3,3 +3,4 @@ missing-ip-error=Missing IP address in HTTP forwarded header.
 ip-user-authenticator-display-name=IP address
 ip-user-authenticator-help-text=Automatically sign in with your current IP address.
 ipAuthText=Automatically sign in to your account with your IP address.
+max-num-session-error=Maximum number of concurrent sessions reached.

--- a/src/main/resources/theme-resources/messages/messages_es.properties
+++ b/src/main/resources/theme-resources/messages/messages_es.properties
@@ -1,0 +1,6 @@
+invalid-ip-error=Dirección IP no válida.
+missing-ip-error=Dirección IP faltante en el encabezado HTTP reenviado.
+ip-user-authenticator-display-name=Dirección IP
+ip-user-authenticator-help-text=Inicie sesión automáticamente con su dirección IP actual.
+ipAuthText=Inicie sesión automáticamente en su cuenta con su dirección IP.
+max-num-session-error=Se ha alcanzado el número máximo de sesiones simultáneas.

--- a/src/main/resources/theme-resources/messages/messages_fr.properties
+++ b/src/main/resources/theme-resources/messages/messages_fr.properties
@@ -1,0 +1,6 @@
+invalid-ip-error=Adresse IP invalide.
+missing-ip-error=Adresse IP manquante dans l'en-tête HTTP transmise.
+ip-user-authenticator-display-name=Adresse IP
+ip-user-authenticator-help-text=Connectez-vous automatiquement avec votre adresse IP actuelle.
+ipAuthText=Connectez-vous à votre compte avec votre adresse IP.
+max-num-session-error=Nombre maximum de sessions concurrentes atteint.

--- a/src/main/resources/theme-resources/messages/messages_ru.properties
+++ b/src/main/resources/theme-resources/messages/messages_ru.properties
@@ -1,0 +1,6 @@
+invalid-ip-error=Неверный IP-адрес.
+missing-ip-error=Отсутствует IP-адрес в перенаправленном заголовке HTTP.
+ip-user-authenticator-display-name=IP-адрес
+ip-user-authenticator-help-text=Автоматически войти в систему с вашим текущим IP-адресом.
+ipAuthText=Автоматически войти в свою учетную запись с вашим IP-адресом.
+max-num-session-error=Достигнуто максимальное количество одновременных сессий.

--- a/src/main/resources/theme-resources/messages/messages_zh_CN.properties
+++ b/src/main/resources/theme-resources/messages/messages_zh_CN.properties
@@ -1,0 +1,6 @@
+invalid-ip-error=无效的 IP 地址。
+missing-ip-error=HTTP 转发头中缺少 IP 地址。
+ip-user-authenticator-display-name=IP 地址
+ip-user-authenticator-help-text=使用您当前的 IP 地址自动登录。
+ipAuthText=使用您的 IP 地址自动登录到您的账户。
+max-num-session-error=已达到最大并发会话数。


### PR DESCRIPTION
We have a need to limit the maximum number of concurrent session at a user level for ip authenticated users.
So I add it to your plugin.

If it's something you found useful, feel free to accept this pull request :).

FYI, the german translation was generated by AI, don't know if it's relevant or not (even if I know a bit of german I don't know the technical terms).