### PR TITLE
fix: harden trusted-proxies-count config parsing to prevent server errors

### DIFF
--- a/src/main/java/org/n52/keycloak/authentication/IPUserAuthenticatorConfig.java
+++ b/src/main/java/org/n52/keycloak/authentication/IPUserAuthenticatorConfig.java
@@ -36,6 +36,7 @@ public class IPUserAuthenticatorConfig {
             return DEFAULT_TRUSTED_PROXIES_COUNT;
         }
         
+    
         try {
             int count = Integer.parseInt(trustedProxiesCountStr.trim());
             
@@ -46,7 +47,8 @@ public class IPUserAuthenticatorConfig {
             
             return count;
         } catch (NumberFormatException e) {
-            LOG.warn("Configuration value for 'trusted-proxies-count' is not a valid integer: '" + trustedProxiesCountStr + "'. Using default value: " + DEFAULT_TRUSTED_PROXIES_COUNT, e);
+            LOG.warn("Configuration value for 'trusted-proxies-count' is not a valid integer: '" + trustedProxiesCountStr + "'. Using default value: " + DEFAULT_TRUSTED_PROXIES_COUNT);
+            LOG.trace("Exception while parsing 'trusted-proxies-count'", e);
             return DEFAULT_TRUSTED_PROXIES_COUNT;
         }
     }

--- a/src/main/java/org/n52/keycloak/authentication/IPUserAuthenticatorConfig.java
+++ b/src/main/java/org/n52/keycloak/authentication/IPUserAuthenticatorConfig.java
@@ -1,12 +1,18 @@
 package org.n52.keycloak.authentication;
 
-import org.keycloak.models.AuthenticatorConfigModel;
-
 import java.util.Map;
 
-import static org.n52.keycloak.authentication.IPUserAuthenticatorFactory.*;
+import org.jboss.logging.Logger;
+import org.keycloak.models.AuthenticatorConfigModel;
+import static org.n52.keycloak.authentication.IPUserAuthenticatorFactory.CONF_FORWARDED_HEADER_NAME;
+import static org.n52.keycloak.authentication.IPUserAuthenticatorFactory.CONF_FORWARDED_HEADER_NAME_DEFAULT;
+import static org.n52.keycloak.authentication.IPUserAuthenticatorFactory.CONF_TRUSTED_PROXIES_COUNT;
+import static org.n52.keycloak.authentication.IPUserAuthenticatorFactory.CONF_USE_FORWARDED_HEADER;
 
 public class IPUserAuthenticatorConfig {
+
+    private static final Logger LOG = Logger.getLogger(IPUserAuthenticatorConfig.class);
+    private static final int DEFAULT_TRUSTED_PROXIES_COUNT = 1;
 
     private boolean useForwardedHeader;
     private String forwardedHeaderName;
@@ -19,7 +25,30 @@ public class IPUserAuthenticatorConfig {
     IPUserAuthenticatorConfig(Map<String, String> configMap) {
         this.useForwardedHeader = Boolean.parseBoolean(configMap.get(CONF_USE_FORWARDED_HEADER));
         this.forwardedHeaderName = configMap.getOrDefault(CONF_FORWARDED_HEADER_NAME, CONF_FORWARDED_HEADER_NAME_DEFAULT);
-        this.trustedProxiesCount = Integer.parseInt(configMap.get(CONF_TRUSTED_PROXIES_COUNT));
+        this.trustedProxiesCount = parseTrustedProxiesCount(configMap);
+    }
+
+    private int parseTrustedProxiesCount(Map<String, String> configMap) {
+        String trustedProxiesCountStr = configMap.getOrDefault(CONF_TRUSTED_PROXIES_COUNT, String.valueOf(DEFAULT_TRUSTED_PROXIES_COUNT));
+        
+        if (trustedProxiesCountStr == null || trustedProxiesCountStr.trim().isEmpty()) {
+            LOG.warn("Configuration value for 'trusted-proxies-count' is missing or empty. Using default value: " + DEFAULT_TRUSTED_PROXIES_COUNT);
+            return DEFAULT_TRUSTED_PROXIES_COUNT;
+        }
+        
+        try {
+            int count = Integer.parseInt(trustedProxiesCountStr.trim());
+            
+            if (count < 1) {
+                LOG.warn("Configuration value for 'trusted-proxies-count' must be >= 1. Got: " + count + ". Using default value: " + DEFAULT_TRUSTED_PROXIES_COUNT);
+                return DEFAULT_TRUSTED_PROXIES_COUNT;
+            }
+            
+            return count;
+        } catch (NumberFormatException e) {
+            LOG.warn("Configuration value for 'trusted-proxies-count' is not a valid integer: '" + trustedProxiesCountStr + "'. Using default value: " + DEFAULT_TRUSTED_PROXIES_COUNT, e);
+            return DEFAULT_TRUSTED_PROXIES_COUNT;
+        }
     }
 
     public boolean isUseForwardedHeader() {


### PR DESCRIPTION
## Description

This PR hardens the parsing of the `trusted-proxies-count` configuration in the IP authenticator to prevent server-side failures caused by misconfiguration.

### What was fixed

- Previously, the authenticator could throw a server-side exception (HTTP 500) when `trusted-proxies-count` was missing, empty, or non-numeric.
- The configuration value is now parsed safely:
  - If the value is missing, empty, non-numeric, or less than `1`, a safe default of `1` is applied.
  - Invalid configurations are handled gracefully and no longer cause unhandled exceptions.
  - Clear warning messages are logged to inform administrators about invalid configuration values.
- This ensures the authentication flow remains stable and fails safely under misconfiguration.

Fixes #2
